### PR TITLE
request.data[‘key’] KeyError 처리 함수

### DIFF
--- a/django_app/regiclass/views/lecture.py
+++ b/django_app/regiclass/views/lecture.py
@@ -11,6 +11,7 @@ from member.models import Tutor
 from regiclass.models import Lecture, ClassLocation
 from regiclass.serializers import LectureListSerializer, LectureMakeSerializer
 from regiclass.serializers.lecture import LectureUpdateSerializer
+from utils.custom_exceptions.functions import custom_key_error
 
 MyUser = get_user_model()
 
@@ -71,9 +72,9 @@ class LectureList(APIView):
     serializer_class = LectureListSerializer
 
     def post(self, request):
-        search_text = request.POST.get('search_text', '')
-        order_by = request.POST.get('ordering', '-modify_date')
-        category = request.POST.get('category', '')
+        search_text = custom_key_error(request, 'search_text', '')
+        order_by = custom_key_error(request, 'ordering', '-modify_date')
+        category = custom_key_error(request, 'category', '')
         state = request.POST.get('state', Lecture.STATE_ACTIVITY)
         lecture_list = Lecture.objects.filter(
             (Q(title__contains=search_text) | Q(tutor__author__nickname__contains=search_text))

--- a/django_app/utils/custom_exceptions/functions.py
+++ b/django_app/utils/custom_exceptions/functions.py
@@ -10,3 +10,11 @@ def custom_index_error(validated_data, key, length):
         return validated_data[key]
     else:
         raise CustomIndexError(key)
+
+
+def custom_key_error(request, key, default=''):
+    try:
+        result = request.data[key]
+    except KeyError:
+        result = default
+    return result


### PR DESCRIPTION
        modified:   regiclass/views/lecture.py
        modified:   utils/custom_exceptions/functions.py

request.data[‘key’] 로 데이터 가지고 올 때 KeyError 로 Exception 발생 하면
기본값을 대신 리턴해주는 함수

ex)
custom_key_error(request, 'ordering', '-modify_date')
request.data에 ordering키의 데이터가 없을 경우 -modify_date 문자열을 리턴 함